### PR TITLE
Feat: 간편 로그인 관련 기능 추가(테스트 필요)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -49,57 +49,69 @@ const Header = () => {
     setSocialLogin
   } = userStore()
 
+  const isSocialLoginGoogle = socialLogin === 'google'
+  const isSocialLoginKakao = socialLogin === 'kakao'
+
   const handleBack = () => {
     if (isTripDetail) {
       navigate(-1)
       return
-    } else if (isSearchTravel || isSearchCommunity) {
+    }
+    if (isSearchTravel || isSearchCommunity) {
       navigate('/')
       return
-    } else if (isCommunityDetail) {
+    }
+    if (isCommunityDetail) {
       navigate('/community')
       return
     }
-    if (socialLogin === 'google') {
+    if (isSocialLoginGoogle) {
       if (isRegisterAge) {
         resetAge()
         navigate('/login')
         setSocialLogin(null)
-      } else if (isRegisterGender) {
-        resetGender()
-        navigate(-1)
-      } else {
-        navigate(-1)
+        return
       }
-      return
-    } else if (socialLogin === 'kakao') {
-      if (isRegisterAge) {
-        resetAge()
-        navigate('/registerForm')
-      } else if (isRegisterGender) {
+      if (isRegisterGender) {
         resetGender()
         navigate(-1)
-      } else if (isRegisterForm) {
-        navigate('/login')
-        resetForm()
-        setSocialLogin(null)
-      } else {
-        navigate(-1)
-      }
-      return
-    } else {
-      if (isRegisterForm) {
-        resetForm()
-      } else if (isRegisterName) {
-        resetName()
-      } else if (isRegisterAge) {
-        resetAge()
-      } else if (isRegisterGender) {
-        resetGender()
+        return
       }
       navigate(-1)
       return
     }
+    if (isSocialLoginKakao) {
+      if (isRegisterAge) {
+        resetAge()
+        navigate('/registerForm')
+        return
+      }
+      if (isRegisterGender) {
+        resetGender()
+        navigate(-1)
+        return
+      }
+      if (isRegisterForm) {
+        navigate('/login')
+        resetForm()
+        setSocialLogin(null)
+        return
+      }
+      navigate(-1)
+
+      return
+    }
+    if (isRegisterForm) {
+      resetForm()
+    } else if (isRegisterName) {
+      resetName()
+    } else if (isRegisterAge) {
+      resetAge()
+    } else if (isRegisterGender) {
+      resetGender()
+    }
+    navigate(-1)
+    return
   }
   return (
     <HeaderContainer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -40,7 +40,14 @@ const Header = () => {
   const isRegisterForm = location.pathname.startsWith('/registerForm')
   const isRegisterName = location.pathname.startsWith('/registerName')
 
-  const { resetAge, resetForm, resetGender, resetName } = userStore()
+  const {
+    resetAge,
+    resetForm,
+    resetGender,
+    resetName,
+    socialLogin,
+    setSocialLogin
+  } = userStore()
 
   const handleBack = () => {
     if (isTripDetail) {
@@ -53,17 +60,46 @@ const Header = () => {
       navigate('/community')
       return
     }
-
-    if (isRegisterForm) {
-      resetForm()
-    } else if (isRegisterName) {
-      resetName()
-    } else if (isRegisterAge) {
-      resetAge()
-    } else if (isRegisterGender) {
-      resetGender()
+    if (socialLogin === 'google') {
+      if (isRegisterAge) {
+        resetAge()
+        navigate('/login')
+        setSocialLogin(null)
+      } else if (isRegisterGender) {
+        resetGender()
+        navigate(-1)
+      } else {
+        navigate(-1)
+      }
+      return
+    } else if (socialLogin === 'kakao') {
+      if (isRegisterAge) {
+        resetAge()
+        navigate('/registerForm')
+      } else if (isRegisterGender) {
+        resetGender()
+        navigate(-1)
+      } else if (isRegisterForm) {
+        navigate('/login')
+        resetForm()
+        setSocialLogin(null)
+      } else {
+        navigate(-1)
+      }
+      return
+    } else {
+      if (isRegisterForm) {
+        resetForm()
+      } else if (isRegisterName) {
+        resetName()
+      } else if (isRegisterAge) {
+        resetAge()
+      } else if (isRegisterGender) {
+        resetGender()
+      }
+      navigate(-1)
+      return
     }
-    navigate(-1)
   }
   return (
     <HeaderContainer>

--- a/src/constants/socialLogin.ts
+++ b/src/constants/socialLogin.ts
@@ -1,13 +1,13 @@
-export const redirectUri = `${import.meta.env.VITE_BASE_URL}/login/oauth/kakao`
+export const redirectUri = `${import.meta.env.VITE_BASE_URL}/login/oauth/kakao/callback`
 
 export const KAKAO_LINK = `http://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_KAKAO_CLIENT_ID}&redirect_uri=${redirectUri}&response_type=code`
 
 export const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID // 발급받은 클라이언트 아이디
-export const NAVER_REDIRECT_URI = `${import.meta.env.VITE_BASE_URL}/login/oauth/naver` // Callback URL
+export const NAVER_REDIRECT_URI = `${import.meta.env.VITE_BASE_URL}/login/oauth/naver/callback` // Callback URL
 export const STATE = 'develop'
 export const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&state=${STATE}&redirect_uri=${NAVER_REDIRECT_URI}`
 
-export const GOOGLE_REDIRECT_URI = `${import.meta.env.VITE_BASE_URL}/login/oauth/google`
+export const GOOGLE_REDIRECT_URI = `${import.meta.env.VITE_BASE_URL}/login/oauth/google/callback`
 
 export const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID
 export const GOOGLE_LINK = `https://accounts.google.com/o/oauth2/v2/auth?

--- a/src/hooks/user/useAuth.ts
+++ b/src/hooks/user/useAuth.ts
@@ -7,6 +7,7 @@ import RequestError from '@/context/ReqeustError'
 import { useNavigate } from 'react-router-dom'
 import { IRegisterEmail, IRegisterGoogle, IRegisterKakao } from '@/model/auth'
 import { userStore } from '@/store/client/userStore'
+import { getJWTHeader } from '@/utils/user'
 
 // 로그인, 로그아웃, 이메일회원가입까지 구현
 // 인증 부분을 처리하는 커스텀 훅
@@ -33,11 +34,10 @@ const useAuth = () => {
     }) => {
       if (!checkNetworkConnection()) return
 
-      const response = await axiosInstance.post(
-        '/api/login',
-        { email, password },
-        { withCredentials: true }
-      )
+      const response = await axiosInstance.post('/api/login', {
+        email,
+        password
+      })
       return response.data
     },
     onSuccess: data => {
@@ -62,11 +62,10 @@ const useAuth = () => {
     }) => {
       if (!checkNetworkConnection()) return
 
-      const response = await axiosInstance.post(
-        '/api/social/login',
-        { email, socialLoginId },
-        { withCredentials: true }
-      )
+      const response = await axiosInstance.post('/api/social/login', {
+        email,
+        socialLoginId
+      })
       return response.data
     },
     onSuccess: data => {
@@ -85,9 +84,7 @@ const useAuth = () => {
     mutationFn: async (formData: IRegisterEmail) => {
       if (!checkNetworkConnection()) return
 
-      const response = await axiosInstance.post('/api/users/new', formData, {
-        withCredentials: true
-      })
+      const response = await axiosInstance.post('/api/users/new', formData)
       return response.data
     },
     onSuccess: data => {
@@ -110,9 +107,7 @@ const useAuth = () => {
           ? '/api/social/google/complete-signup'
           : '/api/social/kakao/complete-signup'
 
-      const response = await axiosInstance.post(path, formData, {
-        withCredentials: true
-      })
+      const response = await axiosInstance.put(path, formData)
       return response.data
     },
     onSuccess: data => {
@@ -135,7 +130,11 @@ const useAuth = () => {
     mutationFn: async () => {
       if (!checkNetworkConnection()) return
 
-      return await axiosInstance.post('/api/logout', {})
+      return await axiosInstance.post(
+        '/api/logout',
+        {},
+        { headers: getJWTHeader(accessToken as string) }
+      )
     },
     onSuccess: () => {
       clearLoginData()

--- a/src/model/auth.ts
+++ b/src/model/auth.ts
@@ -1,0 +1,29 @@
+export interface IRegisterEmail {
+  email: string
+  password: string
+  name: string
+  gender: string
+
+  agegroup: string
+  // DB에서 현재 제외된 상태.
+  // introduce: 'string'
+  preferredTags: string[]
+}
+
+export interface IRegisterGoogle {
+  userNumber: number
+  gender: string
+
+  agegroup: string
+  social: 'google' | 'kakao'
+  preferredTags: string[]
+}
+
+export interface IRegisterKakao {
+  userNumber: number
+  gender: string
+  email: string
+  agegroup: string
+  social: 'google' | 'kakao'
+  preferredTags: string[]
+}

--- a/src/pages/Login/OauthGoogle.tsx
+++ b/src/pages/Login/OauthGoogle.tsx
@@ -2,23 +2,41 @@ import React, { useEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import axios from 'axios'
 import { getToken } from '@/api/user'
+import { userStore } from '@/store/client/userStore'
+import useAuth from '@/hooks/user/useAuth'
 
 const OauthGoogle = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const searchParams = new URLSearchParams(location.search)
   const code = searchParams.get('code')
+  const { setSocialLogin } = userStore()
+  const { socialLogin, socialLoginMutation } = useAuth()
+  const { isError, isSuccess } = socialLoginMutation
+
+  useEffect(() => {
+    if (socialLoginMutation.isSuccess) {
+      navigate('/')
+    }
+    if (socialLoginMutation.isError) {
+      alert(socialLoginMutation.isError)
+      navigate('/login')
+    }
+  }, [isSuccess, isError])
 
   useEffect(() => {
     if (code) {
       getToken('google', code)
         .then(user => {
           console.log('user client', user)
-          if (user.id) {
-            navigate('/')
+          if (user?.userStatus === 'PENDING') {
+            navigate('/registerGender')
+            setSocialLogin('google')
           } else {
-            alert('로그인에 실패하였습니다.')
-            navigate('/login')
+            socialLogin({
+              socialLoginId: user?.socialLoginId as string,
+              email: user?.userEmail as string
+            })
           }
         })
         .catch(error => {

--- a/src/pages/Login/OauthKakao.tsx
+++ b/src/pages/Login/OauthKakao.tsx
@@ -2,12 +2,27 @@ import React, { useEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import axios from 'axios'
 import { getToken } from '@/api/user'
+import { userStore } from '@/store/client/userStore'
+import useAuth from '@/hooks/user/useAuth'
 
 const OauthKakao = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const searchParams = new URLSearchParams(location.search)
   const code = searchParams.get('code') // 카카오에서 받은 인증 코드
+  const { setSocialLogin } = userStore()
+  const { socialLogin, socialLoginMutation } = useAuth()
+  const { isError, isSuccess } = socialLoginMutation
+
+  useEffect(() => {
+    if (socialLoginMutation.isSuccess) {
+      navigate('/')
+    }
+    if (socialLoginMutation.isError) {
+      alert(socialLoginMutation.isError)
+      navigate('/login')
+    }
+  }, [isSuccess, isError])
 
   useEffect(() => {
     if (code) {
@@ -16,11 +31,14 @@ const OauthKakao = () => {
       getToken('kakao', code)
         .then(user => {
           console.log('user client', user)
-          if (user.id) {
-            navigate('/')
+          if (user?.userStatus === 'PENDING') {
+            navigate('/registerForm')
+            setSocialLogin('kakao')
           } else {
-            alert('로그인에 실패하였습니다.')
-            navigate('/login')
+            socialLogin({
+              socialLoginId: user?.socialLoginId as string,
+              email: user?.userEmail as string
+            })
           }
         })
         .catch(error => {

--- a/src/pages/Login/OauthNaver.tsx
+++ b/src/pages/Login/OauthNaver.tsx
@@ -2,12 +2,27 @@ import React, { useEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import axios from 'axios'
 import { getToken } from '@/api/user'
+import { userStore } from '@/store/client/userStore'
+import useAuth from '@/hooks/user/useAuth'
 
 const OauthNaver = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const searchParams = new URLSearchParams(location.search)
   const code = searchParams.get('code') // 네이버에서 받은 인증 코드
+  const { socialLogin, socialLoginMutation } = useAuth()
+  const { setSocialLogin } = userStore()
+  const { isSuccess, isPending, isError } = socialLoginMutation
+  useEffect(() => {
+    if (socialLoginMutation.isSuccess) {
+      navigate('/')
+      setSocialLogin('naver')
+    }
+    if (socialLoginMutation.isError) {
+      alert(socialLoginMutation.isError)
+      navigate('/login')
+    }
+  }, [isSuccess, isError])
 
   useEffect(() => {
     if (code) {
@@ -16,12 +31,10 @@ const OauthNaver = () => {
       getToken('naver', code)
         .then(user => {
           console.log('user client', user)
-          if (user.id) {
-            navigate('/')
-          } else {
-            alert('로그인에 실패하였습니다.')
-            navigate('/login')
-          }
+          socialLogin({
+            socialLoginId: user?.socialLoginId as string,
+            email: user?.email as string
+          })
         })
         .catch(error => {
           alert(error)

--- a/src/pages/Register/RegisterAge.tsx
+++ b/src/pages/Register/RegisterAge.tsx
@@ -13,8 +13,16 @@ const AGE_LIST = ['10대', '20대', '30대', '40대', '50대 이상']
 
 const RegisterAge = () => {
   const navigate = useNavigate()
-  const { agegroup, addAgegroup, email, name, resetForm, resetName } =
-    userStore()
+  const {
+    agegroup,
+    addAgegroup,
+    email,
+    name,
+    resetForm,
+    resetName,
+    socialLogin,
+    setSocialLogin
+  } = userStore()
   const [genderCheck, setGenderCheck] = useState(false)
 
   const nextStepClickHandler = () => {
@@ -32,10 +40,17 @@ const RegisterAge = () => {
   }
 
   useEffect(() => {
-    if (!email && !name) {
+    if (socialLogin === 'naver') {
       resetName()
       resetForm()
-      navigate('/registerForm')
+      setSocialLogin(null)
+      navigate('/login')
+    } else if (socialLogin === 'kakao' || socialLogin === null) {
+      if (!email && !name) {
+        resetName()
+        resetForm()
+        navigate('/registerForm')
+      }
     }
   }, [email, name])
 

--- a/src/pages/Register/RegisterAge.tsx
+++ b/src/pages/Register/RegisterAge.tsx
@@ -24,6 +24,9 @@ const RegisterAge = () => {
     setSocialLogin
   } = userStore()
   const [genderCheck, setGenderCheck] = useState(false)
+  const isEmailRegister = socialLogin === null
+  const isSocialLoginKakao = socialLogin === 'kakao'
+  const isSocialLoginNaver = socialLogin === 'naver'
 
   const nextStepClickHandler = () => {
     if (agegroup) {
@@ -40,12 +43,12 @@ const RegisterAge = () => {
   }
 
   useEffect(() => {
-    if (socialLogin === 'naver') {
+    if (isSocialLoginNaver) {
       resetName()
       resetForm()
       setSocialLogin(null)
       navigate('/login')
-    } else if (socialLogin === 'kakao' || socialLogin === null) {
+    } else if (isSocialLoginKakao || isEmailRegister) {
       if (!email && !name) {
         resetName()
         resetForm()

--- a/src/pages/Register/RegisterForm.tsx
+++ b/src/pages/Register/RegisterForm.tsx
@@ -48,18 +48,20 @@ const RegisterForm = () => {
   })
 
   const navigate = useNavigate()
+  const isSocialLoginGoogle = socialLogin === 'google'
+  const isSocialLoginKakao = socialLogin === 'kakao'
+  const isSocialLoginNaver = socialLogin === 'naver'
 
-  const allSuccess =
-    socialLogin === 'kakao'
-      ? success.email
-      : Object.values(success).every(value => value)
+  const allSuccess = isSocialLoginKakao
+    ? success.email
+    : Object.values(success).every(value => value)
 
   const closeShowTerms = () => {
     setShowTerms(false)
   }
 
   useEffect(() => {
-    if (socialLogin === 'google' || socialLogin === 'naver') {
+    if (isSocialLoginGoogle || isSocialLoginNaver) {
       setSocialLogin(null)
       navigate('/login')
     }
@@ -159,7 +161,7 @@ const RegisterForm = () => {
       }
 
       addEmail(formData.email)
-      if (socialLogin === 'kakao') {
+      if (isSocialLoginKakao) {
         navigate('/registerGender')
       } else {
         addPassword(formData.password)

--- a/src/pages/Register/RegisterForm.tsx
+++ b/src/pages/Register/RegisterForm.tsx
@@ -5,7 +5,7 @@ import Spacing from '@/components/Spacing'
 import Terms from '@/components/Terms'
 import { userStore } from '@/store/client/userStore'
 import styled from '@emotion/styled'
-import React, { ChangeEvent, FormEvent, useState } from 'react'
+import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { checkEmail } from '@/api/user'
 import ButtonContainer from '@/components/ButtonContainer'
@@ -17,7 +17,14 @@ interface ErrorProps {
 }
 
 const RegisterForm = () => {
-  const { addEmail, addPassword, email, password } = userStore()
+  const {
+    addEmail,
+    addPassword,
+    email,
+    password,
+    socialLogin,
+    setSocialLogin
+  } = userStore()
   const [showTerms, setShowTerms] = useState(true)
   const [formData, setFormData] = useState({
     email: email,
@@ -42,11 +49,21 @@ const RegisterForm = () => {
 
   const navigate = useNavigate()
 
-  const allSuccess = Object.values(success).every(value => value)
+  const allSuccess =
+    socialLogin === 'kakao'
+      ? success.email
+      : Object.values(success).every(value => value)
 
   const closeShowTerms = () => {
     setShowTerms(false)
   }
+
+  useEffect(() => {
+    if (socialLogin === 'google' || socialLogin === 'naver') {
+      setSocialLogin(null)
+      navigate('/login')
+    }
+  }, [socialLogin])
 
   const handleRemoveValue = (
     name: 'email' | 'password' | 'confirmPassword'
@@ -142,8 +159,12 @@ const RegisterForm = () => {
       }
 
       addEmail(formData.email)
-      addPassword(formData.password)
-      navigate('/registerName')
+      if (socialLogin === 'kakao') {
+        navigate('/registerGender')
+      } else {
+        addPassword(formData.password)
+        navigate('/registerName')
+      }
     } else {
       setShake({
         email: Boolean(error.email),
@@ -184,50 +205,54 @@ const RegisterForm = () => {
         </FieldContainer>
 
         <Spacing size={'6svh'} />
-        <FieldContainer>
-          <Label htmlFor="password">비밀번호</Label>
-          <Spacing size={16} />
-          <InputField
-            handleRemoveValue={() => handleRemoveValue('password')}
-            type="password"
-            onChange={changeValue}
-            shake={shake.password}
-            name="password"
-            placeholder="비밀번호 입력"
-            hasError={Boolean(error.password)}
-            value={formData.password}
-            success={success.password}
-          />
-          <Spacing size={10} />
-          {error.password ? (
-            <InfoText hasError>{error.password}</InfoText>
-          ) : success.password ? (
-            <InfoText success>영문 대문자, 특수문자 포함 8~20자</InfoText>
-          ) : (
-            <InfoText>영문 대문자, 특수문자 포함 8~20자</InfoText>
-          )}
-        </FieldContainer>
+        {Boolean(socialLogin) && (
+          <>
+            <FieldContainer>
+              <Label htmlFor="password">비밀번호</Label>
+              <Spacing size={16} />
+              <InputField
+                handleRemoveValue={() => handleRemoveValue('password')}
+                type="password"
+                onChange={changeValue}
+                shake={shake.password}
+                name="password"
+                placeholder="비밀번호 입력"
+                hasError={Boolean(error.password)}
+                value={formData.password}
+                success={success.password}
+              />
+              <Spacing size={10} />
+              {error.password ? (
+                <InfoText hasError>{error.password}</InfoText>
+              ) : success.password ? (
+                <InfoText success>영문 대문자, 특수문자 포함 8~20자</InfoText>
+              ) : (
+                <InfoText>영문 대문자, 특수문자 포함 8~20자</InfoText>
+              )}
+            </FieldContainer>
 
-        <Spacing size={14} />
-        <FieldContainer>
-          <InputField
-            shake={shake.confirmPassword}
-            handleRemoveValue={() => handleRemoveValue('confirmPassword')}
-            type="password"
-            name="confirmPassword"
-            placeholder="비밀번호 재입력"
-            onChange={changeValue}
-            hasError={Boolean(error.confirmPassword)}
-            value={formData.confirmPassword}
-            success={success.confirmPassword}
-          />
-          <Spacing size={10} />
-          {error.confirmPassword ? (
-            <InfoText hasError>{error.confirmPassword}</InfoText>
-          ) : (
-            <Spacing size={16} />
-          )}
-        </FieldContainer>
+            <Spacing size={14} />
+            <FieldContainer>
+              <InputField
+                shake={shake.confirmPassword}
+                handleRemoveValue={() => handleRemoveValue('confirmPassword')}
+                type="password"
+                name="confirmPassword"
+                placeholder="비밀번호 재입력"
+                onChange={changeValue}
+                hasError={Boolean(error.confirmPassword)}
+                value={formData.confirmPassword}
+                success={success.confirmPassword}
+              />
+              <Spacing size={10} />
+              {error.confirmPassword ? (
+                <InfoText hasError>{error.confirmPassword}</InfoText>
+              ) : (
+                <Spacing size={16} />
+              )}
+            </FieldContainer>
+          </>
+        )}
         <ButtonContainer>
           {allSuccess ? (
             <Button text="다음" />

--- a/src/pages/Register/RegisterGender.tsx
+++ b/src/pages/Register/RegisterGender.tsx
@@ -28,6 +28,10 @@ const RegisterGender = () => {
   const [femaleClicked, setFemaleClicked] = useState(sex == 'F' ? true : false)
   const navigate = useNavigate()
 
+  const isSocialLoginKakao = socialLogin === 'kakao'
+  const isSocialLoginNaver = socialLogin === 'naver'
+  const isSocialLoginGoogle = socialLogin === 'google'
+
   const clickedMale = () => {
     if (!maleClicked) {
       setMaleClicked(true)
@@ -46,21 +50,21 @@ const RegisterGender = () => {
   }
 
   useEffect(() => {
-    if (socialLogin === 'google') {
+    if (isSocialLoginGoogle) {
       if (!agegroup) {
         resetAge()
         setSocialLogin(null)
         resetName()
         navigate('/login')
       }
-    } else if (socialLogin === 'kakao') {
+    } else if (isSocialLoginKakao) {
       if (!email || !agegroup) {
         resetName()
         resetForm()
         resetAge()
         navigate('/registerForm')
       }
-    } else if (socialLogin === 'naver') {
+    } else if (isSocialLoginNaver) {
       resetName()
       resetForm()
       resetAge()

--- a/src/pages/Register/RegisterGender.tsx
+++ b/src/pages/Register/RegisterGender.tsx
@@ -12,8 +12,18 @@ interface ContextType {
 const RegisterGender = () => {
   // Outlet으로 렌더링 될 하위 컴포넌트에 Props로 성별 선택확인 변수 전달.
   const { setGenderCheck } = useOutletContext<ContextType>()
-  const { sex, addSex, name, email, agegroup, resetAge, resetName, resetForm } =
-    userStore()
+  const {
+    sex,
+    addSex,
+    name,
+    email,
+    agegroup,
+    resetAge,
+    resetName,
+    resetForm,
+    socialLogin,
+    setSocialLogin
+  } = userStore()
   const [maleClicked, setMaleClicked] = useState(sex == 'M' ? true : false)
   const [femaleClicked, setFemaleClicked] = useState(sex == 'F' ? true : false)
   const navigate = useNavigate()
@@ -36,13 +46,35 @@ const RegisterGender = () => {
   }
 
   useEffect(() => {
-    if (!email && !name && !agegroup) {
+    if (socialLogin === 'google') {
+      if (!agegroup) {
+        resetAge()
+        setSocialLogin(null)
+        resetName()
+        navigate('/login')
+      }
+    } else if (socialLogin === 'kakao') {
+      if (!email || !agegroup) {
+        resetName()
+        resetForm()
+        resetAge()
+        navigate('/registerForm')
+      }
+    } else if (socialLogin === 'naver') {
       resetName()
       resetForm()
       resetAge()
-      navigate('/registerForm')
+      setSocialLogin(null)
+      navigate('/login')
+    } else {
+      if (!email || !name || !agegroup) {
+        resetName()
+        resetForm()
+        resetAge()
+        navigate('/registerForm')
+      }
     }
-  }, [email, name, agegroup])
+  }, [email, name, agegroup, socialLogin])
 
   // 이전 화면으로 돌아왔을 때, 이미 체크 했다면, true값을 할당해주기.
   useEffect(() => {

--- a/src/pages/Register/RegisterName.tsx
+++ b/src/pages/Register/RegisterName.tsx
@@ -31,8 +31,11 @@ const RegisterName = () => {
     setSocialLogin
   } = userStore()
   const [userName, setUserName] = useState(name)
+
+  const isEmailRegister = socialLogin === null
+
   useEffect(() => {
-    if (socialLogin !== null) {
+    if (isEmailRegister) {
       resetName()
       resetForm()
       setSocialLogin(null)

--- a/src/pages/Register/RegisterName.tsx
+++ b/src/pages/Register/RegisterName.tsx
@@ -20,14 +20,29 @@ const RegisterName = () => {
 
   const navigate = useNavigate()
 
-  const { name, addName, email, password, resetName } = userStore()
+  const {
+    name,
+    addName,
+    email,
+    password,
+    resetName,
+    socialLogin,
+    resetForm,
+    setSocialLogin
+  } = userStore()
   const [userName, setUserName] = useState(name)
   useEffect(() => {
+    if (socialLogin !== null) {
+      resetName()
+      resetForm()
+      setSocialLogin(null)
+      navigate('/login')
+    }
     if (!email || !password) {
       resetName()
       navigate('/registerForm')
     }
-  }, [email, password])
+  }, [email, password, socialLogin])
 
   const handleRemoveValue = () => setUserName('')
   const nextStepClickHandler = () => {

--- a/src/pages/Register/RegisterTripStyle.tsx
+++ b/src/pages/Register/RegisterTripStyle.tsx
@@ -62,8 +62,13 @@ const RegisterTripStyle = () => {
     setSocialLogin
   } = userStore()
 
+  const isSocialLoginKakao = socialLogin === 'kakao'
+  const isSocialLoginNaver = socialLogin === 'naver'
+  const isRegisterEmail = socialLogin === null
+  const isSocialLoginGoogle = socialLogin === 'google'
+
   useEffect(() => {
-    if (socialLogin === 'google') {
+    if (isSocialLoginGoogle) {
       if (!agegroup || !sex) {
         setSocialLogin(null)
         resetName()
@@ -72,14 +77,14 @@ const RegisterTripStyle = () => {
         resetGender()
         navigate('/login')
       }
-    } else if (socialLogin === 'kakao') {
+    } else if (isSocialLoginKakao) {
       if (!email || !agegroup || !sex) {
         resetForm()
         resetAge()
         resetGender()
         navigate('/registerForm')
       }
-    } else if (socialLogin === 'naver') {
+    } else if (isSocialLoginNaver) {
       setSocialLogin(null)
       resetName()
       resetForm()
@@ -146,7 +151,7 @@ const RegisterTripStyle = () => {
   }
 
   const completeHandler = () => {
-    if (socialLogin === null) {
+    if (isRegisterEmail) {
       registerEmail({
         email,
         password,
@@ -155,14 +160,14 @@ const RegisterTripStyle = () => {
         agegroup: agegroup as string,
         preferredTags: tripStyleArray
       })
-    } else if (socialLogin === 'google') {
+    } else if (isSocialLoginGoogle) {
       registerSocial({
         gender: sex,
         agegroup: agegroup as string,
         preferredTags: tripStyleArray,
         social: 'google'
       } as IRegisterGoogle)
-    } else if (socialLogin === 'kakao') {
+    } else if (isSocialLoginKakao) {
       registerSocial({
         gender: sex,
         email: email,

--- a/src/store/client/userStore.ts
+++ b/src/store/client/userStore.ts
@@ -4,6 +4,8 @@ import { create } from 'zustand'
 type Gender = 'F' | 'M' | ''
 
 interface userState {
+  socialLogin: null | 'kakao' | 'naver' | 'google'
+  setSocialLogin: (social: null | 'kakao' | 'naver' | 'google') => void
   email: string
   addEmail: (email: string) => void
   password: string
@@ -23,6 +25,10 @@ interface userState {
 }
 
 export const userStore = create<userState>(set => ({
+  socialLogin: null,
+  setSocialLogin: social => {
+    set({ socialLogin: social })
+  },
   name: '',
   addName: name => {
     set(state => ({ name: name }))


### PR DESCRIPTION
1. 전체적으로 소셜 로그인과 같은 기능을 추가했습니다.

- 구글과 카카오는 유저 상태를 보고 추가 정보를 받아야하면 socialLogin이라는 정보에 어떤 플랫폼인지 명시하고 회원가입 파트로 넘어갔고, 바로 로그인이 가능한 유저면 소셜 로그인을 진행시켰습니다. 네이버는 socialLogin에 naver 정보만 넣고 실제 로그인 시도를 진행했습니다. 그리고 로그아웃을 할 때 그 socialLogin데이터를 리셋 시키는 코드를 추가하였습니다.
- 각각의 회원가입 파트에서는 플랫폼 별로 어떤 데이터가 필요한지에 대한 필터링 조건을 추가하였고, 마찬가지로 플랫폼 별로 접속 제한 코드도 추가하였습니다.
- 다만 위 부분에서 플랫폼 별로 필요한 데이터가 모두 미묘하게 다르고 그거에 대한 케이스를 다 넣어줘야 하다 보니 코드가 좀 많이 지저분해졌네요..
- 위 추가 사항들은 백엔드와 연결이 필요한 부분이라 실제 머지 후 테스트를 진행하면서 계속 수정해 나갈 것으로 생각됩니다.
- 기타 소셜 로그인 리다이렉트 uri 관련 잘못 적용한 부분이 있어 그 부분 수정했습니다.