### PR TITLE
Fix: 여행 수정 수정

### DIFF
--- a/src/page/TripDetail/TripEdit.tsx
+++ b/src/page/TripDetail/TripEdit.tsx
@@ -130,7 +130,14 @@ const TripEdit = () => {
 
   useEffect(() => {
     console.log(title, "title");
-    if (title === "" && initTitle) {
+    if (
+      title === "" &&
+      initTitle &&
+      locationName.locationName === "" &&
+      initLocationName.locationName &&
+      details === "" &&
+      initDetails
+    ) {
       addTitle(initTitle);
       addDetails(initDetails || "");
       addTags(initTags || []);


### PR DESCRIPTION
상세 페이지 관련
- [ ] 수정완료하고 나서, 바로 다시 수정하면 이전 데이터들이 저장되어 있어요.
- [ ] 비회원 게스트일 경우 홈화면 처럼 하트를 누르면 로그인 안내 모달이 필요할거 같아요.
- [ ]  크라운 아이콘은 개설자한테만 붙어야 할 것 같은데 모두에게 붙어요
- [ ] 제목을 지울 때 동작이 이상합니다. x 버튼을 누를 경우에는 제목이 사라지지 않고, 백스페이스로 제목을 지울 경우에는 마지막 한글자에서 다시 전체 제목으로 되돌아갑니다. 두 경우 모두 문제가 발생할 때 다른 항목의 수정 사항까지 초기화됩니다.

참가 신청 취소가 클리커블 하지 않아서 취소가 가능하다는 걸 인지하기 어려워요(보류)