### PR TITLE
fix: 마이페이지 렌더링 null 반환 문제 수정

### DIFF
--- a/src/components/userProfile/UserProfileDetail.tsx
+++ b/src/components/userProfile/UserProfileDetail.tsx
@@ -13,6 +13,7 @@ import WarningIcon from "../icons/WarningIcon";
 import { userProfileOverlayStore } from "@/store/client/userProfileOverlayStore";
 import useUserProfile from "@/hooks/userProfile/useUserProfile";
 import ProfileRightVectorIcon from "../icons/ProfileRightVectorIcon";
+import { authStore } from "@/store/client/authStore";
 
 interface UserProfileDetailProps {
   isMyPage?: boolean;
@@ -22,7 +23,32 @@ export default function UserProfileDetail({ isMyPage = false }: UserProfileDetai
   const { userProfileInfo } = useUserProfile();
   const navigateWithTransition = useViewTransition();
 
-  if (!userProfileInfo) return null;
+  if (!isMyPage && !userProfileInfo) return null;
+
+  const profileData = isMyPage
+    ? {
+        ageGroup: myPageStore().agegroup,
+        name: myPageStore().name,
+        recentReportCount: 0,
+        userRegDate: "",
+        preferredTags: myPageStore().preferredTags,
+        travelDistance: myPageStore().travelDistance,
+        travelBadgeCount: myPageStore().travelBadgeCount,
+        visitedCountryCount: myPageStore().visitedCountryCount,
+        profileImageUrl: myPageStore().profileUrl,
+      }
+    : {
+        ageGroup: userProfileInfo!.ageGroup,
+        name: userProfileInfo!.name,
+        recentReportCount: userProfileInfo!.recentReportCount,
+        userRegDate: userProfileInfo!.userRegDate,
+        preferredTags: userProfileInfo!.preferredTags,
+        travelDistance: userProfileInfo!.travelDistance,
+        travelBadgeCount: userProfileInfo!.travelBadgeCount,
+        visitedCountryCount: userProfileInfo!.visitedCountryCount,
+        profileImageUrl: userProfileInfo!.profileImageUrl,
+      };
+
   const {
     ageGroup,
     name,
@@ -32,35 +58,25 @@ export default function UserProfileDetail({ isMyPage = false }: UserProfileDetai
     travelDistance,
     travelBadgeCount,
     visitedCountryCount,
-  } = userProfileInfo;
-  const {
-    name: myName,
-    agegroup: myAgeGroup,
-    email: myEmail,
-    preferredTags: myPreferredTags,
-    travelDistance: myTravelDistance,
-    travelBadgeCount: myTravelBageCount,
-    visitedCountryCount: myVisitedCountryCount,
-  } = myPageStore();
+    profileImageUrl,
+  } = profileData;
 
   const TravelMenuList = [
     {
       Icon: CloverIcon,
       label: "방문한 국가",
-      count: isMyPage ? myVisitedCountryCount : visitedCountryCount,
-      nextLink: `/userProfile/${userProfileUserId}/log`,
+      count: visitedCountryCount,
+      nextLink: `/userProfile/${isMyPage ? authStore().userId : userProfileUserId}/log`,
     },
     {
       Icon: CloverIcon,
       label: "여행 배지",
-      count: isMyPage ? myTravelBageCount : travelBadgeCount,
-      nextLink: `/userProfileBadge/${userProfileUserId}`,
+      count: travelBadgeCount,
+      nextLink: `/userProfileBadge/${isMyPage ? authStore().userId : userProfileUserId}`,
     },
   ];
 
-  const preferredTagsTarget = isMyPage ? myPreferredTags : preferredTags;
-
-  const cutTags = preferredTagsTarget.length > 2 ? preferredTagsTarget.slice(0, 2) : preferredTagsTarget;
+  const cutTags = preferredTags.length > 2 ? preferredTags.slice(0, 2) : preferredTags;
 
   const moveToNextLink = (link: string) => {
     navigateWithTransition(link);
@@ -78,15 +94,15 @@ export default function UserProfileDetail({ isMyPage = false }: UserProfileDetai
     <Container>
       <UserInfoContainer>
         <ProfileImgContainer>
-          <RoundedImage src="/images/defaultProfile.png" size={80} />
+          <RoundedImage src={profileImageUrl} size={80} />
         </ProfileImgContainer>
         <UserTextInfoContainer>
           <UserNameBox>
             <Name onClick={isMyPage && editMyProfileInfo}>
-              {isMyPage ? myName : name}
+              {name}
               {isMyPage && <ProfileRightVectorIcon height={16} />}
             </Name>
-            <UserInfo>{isMyPage ? myEmail : userRegDate + "가입"}</UserInfo>
+            <UserInfo>{isMyPage ? myPageStore().email : userRegDate + "가입"}</UserInfo>
           </UserNameBox>
           <UserTags>
             <Badge
@@ -94,7 +110,7 @@ export default function UserProfileDetail({ isMyPage = false }: UserProfileDetai
               fontWeight="600"
               color={palette.keycolor}
               backgroundColor={palette.keycolorBG}
-              text={isMyPage ? myAgeGroup : ageGroup}
+              text={ageGroup}
             />
             {cutTags.map((text: string) => (
               <Badge
@@ -106,7 +122,7 @@ export default function UserProfileDetail({ isMyPage = false }: UserProfileDetai
                 text={text}
               />
             ))}
-            {preferredTagsTarget.length > cutTags.length ? (
+            {preferredTags.length > cutTags.length ? (
               <Badge
                 isDueDate={false}
                 fontWeight="500"
@@ -127,7 +143,7 @@ export default function UserProfileDetail({ isMyPage = false }: UserProfileDetai
       </UserInfoContainer>
       <TravelDistanceContainer>
         <Title>총 여행한 거리✨</Title>
-        <TravelDistance>{formatNumberWithComma(isMyPage ? myTravelDistance : travelDistance)}km</TravelDistance>
+        <TravelDistance>{formatNumberWithComma(travelDistance)}km</TravelDistance>
       </TravelDistanceContainer>
 
       <TravelMenuContainer>


### PR DESCRIPTION
- 컴포넌트 재활용을 통해 isMyPage가 true면 null가 반환해버리는 것이 문제
- 분기처리를 통해 마이페이지면 myPageStore 데이터를, 아니면 api 응답에 대한 데이터를 사용하도록 수정.

## #️⃣이슈 번호
75
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
<!-- 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제 -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인하세요.

<!-- - [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). -->
