### PR TITLE
fix: 여행 뱃기 또는 로그 화면에서 뒤로가기 , 프로필 모달 켜짐 무한 굴레 문제

### DIFF
--- a/src/hooks/useHeaderNavigation.tsx
+++ b/src/hooks/useHeaderNavigation.tsx
@@ -390,6 +390,7 @@ export const useHeaderNavigation = () => {
         // 상대방 프로필 화면의 여행 뱃지 화면
         condition: () => checkRoute.exact(ROUTES.USER_PROFILE_BADGE),
         action: () => {
+          router.back();
           setProfileShow(true);
         },
       },
@@ -397,6 +398,7 @@ export const useHeaderNavigation = () => {
         // 상대방 프로필 화면의 여행 로그 화면,
         condition: () => checkRoute.exact(ROUTES.USER_TRAVEL_LOG),
         action: () => {
+          router.back();
           setProfileShow(true);
         },
       },


### PR DESCRIPTION
- 해당 화면에서 뒤로가기하면 프로필 모달 화면이 보이지만, router.back 통해 이전 화면으로 빠져나갈 수 있또록 수정.

## #️⃣이슈 번호

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
<!-- 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제 -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인하세요.

<!-- - [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). -->
