### PR TITLE
fix : 상대적으로 height가 작은 탭 메뉴의 경우 부모는 overflow가 되어 UI에 뒷배경이 보이는 현상 수정

### DIFF
--- a/src/components/userProfile/UserProfileOverlay.tsx
+++ b/src/components/userProfile/UserProfileOverlay.tsx
@@ -8,6 +8,9 @@ import UserProfileOverlayHeader from "./UserProfileOverlayHeader";
 import UserProfileDetail from "./UserProfileDetail";
 import UserTravelTabMenu from "./UserTravelTabMenu";
 
+const HEADER_DETAIL_HEIGHT = 529;
+const TAB_NAVBAR_HEIGHT = 52;
+
 export default function UserProfileOverlay() {
   const { setProfileShow, profileShow } = userProfileOverlayStore();
   //   const navigateWithTransition = useViewTransition()
@@ -24,6 +27,9 @@ export default function UserProfileOverlay() {
 
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const [height, setHeight] = useState(0);
+  const [selectedTab, setSelectedTab] = useState(0);
+  const [tabHeight, setTabHeight] = useState(0);
+
   useEffect(() => {
     if (bottomRef.current?.parentElement) {
       const scrollHeight = bottomRef.current.parentElement.scrollHeight;
@@ -51,13 +57,22 @@ export default function UserProfileOverlay() {
     };
   }, []);
 
+  useEffect(() => {
+    setHeight(tabHeight + HEADER_DETAIL_HEIGHT + TAB_NAVBAR_HEIGHT);
+  }, [tabHeight]);
+
   return (
     <>
       {profileShow && (
         <OverlayWrapper isClickedCloseBtn={isClickedCloseBtn} height={height}>
           <UserProfileOverlayHeader setIsClickedCloseBtn={setIsClickedCloseBtn} />
           <UserProfileDetail />
-          <UserTravelTabMenu />
+          <UserTravelTabMenu
+            selectedTab={selectedTab}
+            setSelectedTab={setSelectedTab}
+            setTabHeight={setTabHeight}
+            tabHeight={tabHeight}
+          />
           <div ref={bottomRef} style={{ height: "1px" }}></div> {/* 마지막 요소 */}
         </OverlayWrapper>
       )}

--- a/src/components/userProfile/UserProfileOverlayHeader.tsx
+++ b/src/components/userProfile/UserProfileOverlayHeader.tsx
@@ -59,8 +59,8 @@ const ButtonContainer = styled.button`
 // 상단 헤더 스타일
 const HeaderContainer = styled.header<{ isBackGroundColorIsGrey: boolean; isBottomBorder: boolean }>`
   display: flex;
-  padding: 52px 0px 16px 0px;
-  height: 116px;
+  padding: 40px 0px 16px 0px;
+  height: 100px;
   align-items: center;
   gap: 22px;
   position: sticky;

--- a/src/components/userProfile/UserTravelTabMenu.tsx
+++ b/src/components/userProfile/UserTravelTabMenu.tsx
@@ -20,7 +20,7 @@ interface UserTravelTabMenu {
   selectedTab: number;
 }
 const BOX_LAYOUT_HEIGHT = 115;
-export default function UserTravelTabMenu({ setTabHeight, selectedTab, setSelectedTab }: UserTravelTabMenu) {
+export default function UserTravelTabMenu({ tabHeight, setTabHeight, selectedTab, setSelectedTab }: UserTravelTabMenu) {
   const { setProfileShow } = userProfileOverlayStore();
   const navigateWithTransition = useViewTransition();
   const [isClickedCloseBtn, setIsClickedCloseBtn] = useState(false);
@@ -121,7 +121,7 @@ export default function UserTravelTabMenu({ setTabHeight, selectedTab, setSelect
       </TabMenuContainer>
       {/* 조건부 */}
       {/* 0 이 되면 왼쪽으로 이동 1이 되면 오른쪽으로 이동. */}
-      <TravelListBox listBoxHeight={setTabHeight}>
+      <TravelListBox listBoxHeight={tabHeight}>
         <InnerSlider selectedTab={selectedTab}>
           <HostTravelList>
             {isCreatedTravelsNoData && (

--- a/src/components/userProfile/UserTravelTabMenu.tsx
+++ b/src/components/userProfile/UserTravelTabMenu.tsx
@@ -13,11 +13,17 @@ import useInfiniteScroll from "@/hooks/useInfiniteScroll";
 import { IUserRelatedTravelList } from "@/model/userProfile";
 import RoundedImage from "../designSystem/profile/RoundedImage";
 
-export default function UserTravelTabMenu() {
+interface UserTravelTabMenu {
+  tabHeight: number;
+  setTabHeight: React.Dispatch<React.SetStateAction<number>>;
+  setSelectedTab: React.Dispatch<React.SetStateAction<number>>;
+  selectedTab: number;
+}
+const BOX_LAYOUT_HEIGHT = 115;
+export default function UserTravelTabMenu({ setTabHeight, selectedTab, setSelectedTab }: UserTravelTabMenu) {
   const { setProfileShow } = userProfileOverlayStore();
   const navigateWithTransition = useViewTransition();
   const [isClickedCloseBtn, setIsClickedCloseBtn] = useState(false);
-  const [selectedTab, setSelectedTab] = useState(0);
 
   // 스크롤 감지 ref 선언
   const [createdTravelsRef, createdTravelsInView] = useInView();
@@ -47,6 +53,14 @@ export default function UserTravelTabMenu() {
       }, 300);
     }
   }, [isClickedCloseBtn]);
+
+  useEffect(() => {
+    if (selectedTab === 0 && hasNextUserProfileCreatedTravelsPage && userProfileInfo) {
+      setTabHeight(userProfileInfo?.createdTravelCount * BOX_LAYOUT_HEIGHT);
+    } else if (selectedTab === 1 && hasNextUserProfileAppliedTravelsPage && userProfileInfo) {
+      setTabHeight(userProfileInfo?.participatedTravelCount * BOX_LAYOUT_HEIGHT);
+    }
+  }, [selectedTab, isUserProfileAppliedTravelsLoading, isUserProfileCreatedTravelsLoading]);
 
   useInfiniteScroll(() => {
     if (createdTravelsInView) {
@@ -107,7 +121,7 @@ export default function UserTravelTabMenu() {
       </TabMenuContainer>
       {/* 조건부 */}
       {/* 0 이 되면 왼쪽으로 이동 1이 되면 오른쪽으로 이동. */}
-      <TravelListBox>
+      <TravelListBox listBoxHeight={setTabHeight}>
         <InnerSlider selectedTab={selectedTab}>
           <HostTravelList>
             {isCreatedTravelsNoData && (
@@ -261,13 +275,14 @@ const Count = styled.div<TabMenuProps>`
 `;
 
 interface TravelListBoxProps {
-  selectedTab: number;
+  listBoxHeight: number;
 }
 
 export const TravelListBox = styled.div<TravelListBoxProps>`
   width: 100%;
-  overflow-x: hidden;
+  overflow: hidden;
   position: relative;
+  height: ${({ listBoxHeight }) => listBoxHeight}px;
 `;
 
 export const InnerSlider = styled.div<TravelListBoxProps>`


### PR DESCRIPTION
## #️⃣이슈 번호
76
fix: 상대방 프로필 조회 화면 탭메뉴 수정
    - 상대적으로 height가 작은 탭 메뉴의 경우 부모는 overflow가 되어 UI에 뒷배경이 보이는 현상 수정
    
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
<!-- 어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제 -->

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족하는지 확인하세요.

<!-- - [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트). -->
